### PR TITLE
Update configs to allow for return to main/exit and repeat menu

### DIFF
--- a/config.json
+++ b/config.json
@@ -207,6 +207,11 @@
         "sound": "sound:option-is-invalid",
         "skipable": true,
         "postSilence": 0
+      }],
+      "goodbye": [{
+        "sound": "sound:vm-goodbye",
+        "skipable": true,
+        "postSilence": 0
       }]
     }
   },
@@ -229,7 +234,9 @@
         "4": "prev",
         "5": "replay",
         "6": "next",
-        "7": "delete"
+        "7": "delete",
+        "#": "resetExit",
+        "*": "lastOptions"
       }
     }
   },

--- a/config.json
+++ b/config.json
@@ -224,8 +224,10 @@
       },
 
       "changingFolder": {
-        "regex": ".",
-        "action": "submit"
+        "regex": "\\d",
+        "action": "submit",
+        "#": "previousMenu",
+        "*": "repeatMenu"
       },
 
       "ready": {
@@ -235,8 +237,8 @@
         "5": "replay",
         "6": "next",
         "7": "delete",
-        "#": "resetExit",
-        "*": "lastOptions"
+        "#": "previousMenu",
+        "*": "repeatMenu"
       }
     }
   },

--- a/config.json
+++ b/config.json
@@ -219,13 +219,17 @@
   "inputs": {
     "mailboxReader": {
       "waitingForAuth": {
-        "regex": "\\d{4}",
-        "action": "authenticate"
+        "regex": {
+          "match": "\\d{4}",
+          "action": "authenticate"
+        }
       },
 
       "changingFolder": {
-        "regex": "\\d",
-        "action": "submit",
+        "regex": {
+          "match": "\\d",
+          "action": "submit"
+        },
         "#": "previousMenu",
         "*": "repeatMenu"
       },
@@ -241,8 +245,5 @@
         "*": "repeatMenu"
       }
     }
-  },
-
-  "mailbox": {
   }
 }


### PR DESCRIPTION
Adds configuration information necessary for adding the following DTMF buttons:

'*' - repeats the last menu.
'#' - exits from the change folders prompt. If already in the main menu, plays bye and hangs up.
